### PR TITLE
Dump mesh data to jsons on survey completion

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
-from survey3d import Survey, SurveyManager
+from survey3d import Survey, SurveyManager, Mesh
 
 # The app we are serving
 app = FastAPI()
@@ -48,6 +48,10 @@ async def participant(websocket: WebSocket):
                     if manager.survey.startTime == data["survey"]["startTime"]:
                         manager.survey.fromDict(data["survey"])
                         result = manager.saveSurvey()
+                        for mesh in data["meshes"]:
+                            obj = Mesh()
+                            obj.fromDict(data["meshes"][mesh])
+                            obj.saveMesh(manager.data_path)
                     else:
                         print("Cannot save survey with mismatched start time")
                         result = False

--- a/backend/survey3d.py
+++ b/backend/survey3d.py
@@ -22,6 +22,19 @@ class Mesh():
             "faces": self.faces
         }
     
+    def fromDict(self, dict: dict):
+        """
+        Take a dictionary and uses its fields to populate the fields of the
+        Mesh object.
+
+        Args:
+            dictionary: a dictionary with keys named for each property of a
+            Mesh
+        """
+        self.filename = dict["filename"]
+        self.vertices = dict["vertices"]
+        self.faces = dict["faces"]
+    
     def saveMesh(self, path: str):
         """
         Save this Mesh to the given path.

--- a/backend/survey3d.py
+++ b/backend/survey3d.py
@@ -2,6 +2,38 @@ import os
 import json
 from datetime import datetime
 from dataclasses import dataclass, field
+from typing import Sequence
+
+@dataclass
+class Mesh():
+    filename: str
+    vertices: list[Sequence[float]] = field(default_factory = list)
+    faces: list[Sequence[int]] = field(default_factory = list)
+
+    def toDict(self) -> dict:
+        """
+        Return the Mesh's properties as a dictionary.
+
+        Returns: A dictionary of the Mesh's properties.
+        """
+        return {
+            "filename": self.filename,
+            "vertices": self.vertices,
+            "faces": self.faces
+        }
+    
+    def saveMesh(self, path: str):
+        """
+        Save this Mesh to the given path.
+
+        Args:
+            path: The folder to which the .json file should be saved
+        """
+        filename = f"{self.filename}.json"
+        print(f"Saving mesh data to {filename}...")
+        with open(os.path.join(path, filename), 'w') as file:
+            json.dump(self.toDict(), file, indent = 4)
+        return True
 
 @dataclass
 class Quality():

--- a/backend/survey3d.py
+++ b/backend/survey3d.py
@@ -6,7 +6,7 @@ from typing import Sequence
 
 @dataclass
 class Mesh():
-    filename: str
+    filename: str = "default"
     vertices: list[Sequence[float]] = field(default_factory = list)
     faces: list[Sequence[int]] = field(default_factory = list)
 

--- a/frontend/participant/participant.js
+++ b/frontend/participant/participant.js
@@ -454,7 +454,10 @@ function submitCallback() {
 	toggleButtons(false);
 	const surveyValidityError = surveyManager.validateSurvey();
 	if (!surveyValidityError) {
-		if (surveyManager.submitSurveyToServer(socket)) {
+		const meshParams = viewport.getStoredMeshParameters();
+		const meshParamsObject = {meshes: meshParams};
+
+		if (surveyManager.submitSurveyToServer(socket, meshParamsObject)) {
 			startSubmissionTimeout();
 		}
 		else {

--- a/frontend/participant/participant.js
+++ b/frontend/participant/participant.js
@@ -39,39 +39,7 @@ function socketConnect() {
 
 		switch (msg.type) {
 			case "survey":
-				// Initialize a survey using the received data
-				surveyManager.survey = new SVY.Survey();
-				surveyManager.survey.fromJSON(msg.survey);
-				const modelSelect = document.getElementById("modelSelect");
-				// Set the UI to defaults
-				populateSelect(modelSelect, 
-								Object.keys(msg.survey.config.models));
-				populateSelect(document.getElementById("typeSelect"), 
-								msg.survey.config.typeList);
-				
-				cameraController.reset();
-				// If the survey has projected fields, fill the survey table
-				// and click the first "view" button
-				if (surveyManager.survey.projectedFields.length > 0) {
-					surveyTable.update(surveyManager.survey, 0);
-					let field = surveyManager.survey.projectedFields[0];
-					performModelReplacement(
-						surveyManager.survey.config.models[field.model],
-						field.vertices,
-						new THREE.Color("#abcabc"),
-						field.hotSpot
-					);
-				}
-
-				// If the config has hidden scale values, hide them
-				if (surveyManager.survey.config.hideScaleValues) {
-					document.getElementById("intensityValue").innerHTML = "";
-					document.getElementById("naturalnessValue").innerHTML = "";
-					document.getElementById("painValue").innerHTML = "";
-				}
-				if (waitingInterval) { 
-					endWaiting(); 
-				}
+				prepSurvey(msg.survey);
 				break;
 			case "submitResponse":
 				if (msg.success) {
@@ -292,6 +260,54 @@ function populateFieldEditor(field) {
 		painSlider.dispatchEvent(new Event("input"));
 
 		surveyManager.currentField = field;
+	}
+}
+
+/**
+ * Take a survey, give it to the survey manager, and prep the UI to display the 
+ * information contained in that survey.
+ * @param {Survey} survey - the survey whose data is to be used
+ */
+function prepSurvey(survey) {
+	// Initialize a survey using the received data
+	surveyManager.survey = new SVY.Survey();
+	surveyManager.survey.fromJSON(survey);
+	const modelSelect = document.getElementById("modelSelect");
+	// Set the UI to defaults
+	populateSelect(modelSelect, 
+					Object.keys(surveyManager.survey.config.models));
+	populateSelect(document.getElementById("typeSelect"), 
+		surveyManager.survey.config.typeList);
+	
+	cameraController.reset();
+	// If the survey has projected fields, fill the survey table
+	// and click the first "view" button
+	if (surveyManager.survey.projectedFields.length > 0) {
+		surveyTable.update(surveyManager.survey, 0);
+		let field = surveyManager.survey.projectedFields[0];
+		performModelReplacement(
+			surveyManager.survey.config.models[field.model],
+			field.vertices,
+			new THREE.Color("#abcabc"),
+			field.hotSpot
+		);
+	}
+	else {
+		performModelReplacement(
+			surveyManager.survey.config.models[modelSelect.value],
+			null,
+			new THREE.Color("#abcabc")
+		);
+	}
+
+	// If the config has hidden scale values, hide them
+	if (surveyManager.survey.config.hideScaleValues) {
+		document.getElementById("intensityValue").innerHTML = "";
+		document.getElementById("naturalnessValue").innerHTML = "";
+		document.getElementById("painValue").innerHTML = "";
+	}
+	if (waitingInterval) { 
+		endWaiting(); 
 	}
 }
 

--- a/frontend/participant/participant.js
+++ b/frontend/participant/participant.js
@@ -454,7 +454,9 @@ function submitCallback() {
 	toggleButtons(false);
 	const surveyValidityError = surveyManager.validateSurvey();
 	if (!surveyValidityError) {
-		const meshParams = viewport.getStoredMeshParameters();
+		const usedMeshes = surveyManager.survey.usedMeshFilenames;
+		console.log(usedMeshes);
+		const meshParams = viewport.getStoredMeshParameters(usedMeshes);
 		const meshParamsObject = {meshes: meshParams};
 
 		if (surveyManager.submitSurveyToServer(socket, meshParamsObject)) {

--- a/frontend/participant/participant.js
+++ b/frontend/participant/participant.js
@@ -207,6 +207,7 @@ function performModelReplacement(
 				viewport.orbMesh.position.copy(new THREE.Vector3(0, 0, 0));
 				viewport.orbMesh.visible = false;
 			}
+			viewport.getCurrentMeshParameters();
 		}.bind(hotSpot)
 	);
 }

--- a/frontend/participant/participant.js
+++ b/frontend/participant/participant.js
@@ -79,10 +79,10 @@ function socketConnect() {
 					surveyTable.clear();
 					viewport.unloadCurrentMesh();
 					viewport.orbMesh.visible = false;
-					endSubmissionTimeout(msg.success);
+					processSubmissionResult(msg.success);
 				}
 				else if (submissionTimeoutInterval) {
-					endSubmissionTimeout(msg.success);
+					processSubmissionResult(msg.success);
 				}
 				else {
 					alert(
@@ -400,7 +400,7 @@ function startSubmissionTimeout() {
 	var timeoutCount = 0;
 	submissionTimeoutInterval = setInterval(function() {
 		if (timeoutCount == 10) {
-			endSubmissionTimeout(false);
+			processSubmissionResult(false);
 		}
 		timeoutCount += 1;
 	}.bind(timeoutCount), 500);
@@ -412,11 +412,12 @@ function startSubmissionTimeout() {
  * @param {boolean} success - A boolean representing if the submission was a 
  * 		success, determines which alert is displayed
  */
-function endSubmissionTimeout(success) {
+function processSubmissionResult(success) {
 	submissionTimeoutInterval = clearInterval(submissionTimeoutInterval);
 	
 	if (success) {
-		startWaiting()
+		startWaiting();
+		viewport.clearMeshStorage();
 
 		var okFunction = function() {
 			COM.openSidebarTab("waitingTab");
@@ -450,10 +451,10 @@ function endSubmissionTimeout(success) {
  * starts the wait for a new survey to begin.
  */
 function submitCallback() {
+	toggleButtons(false);
 	const surveyValidityError = surveyManager.validateSurvey();
 	if (!surveyValidityError) {
 		if (surveyManager.submitSurveyToServer(socket)) {
-			toggleButtons(false);
 			startSubmissionTimeout();
 		}
 		else {
@@ -462,6 +463,8 @@ function submitCallback() {
 		}
 	}
 	else {
+		toggleButtons(true);
+
 		var goBackButton = function() {
 			openList();
 		}

--- a/frontend/participant/participant.js
+++ b/frontend/participant/participant.js
@@ -207,7 +207,6 @@ function performModelReplacement(
 				viewport.orbMesh.position.copy(new THREE.Vector3(0, 0, 0));
 				viewport.orbMesh.visible = false;
 			}
-			viewport.getCurrentMeshParameters();
 		}.bind(hotSpot)
 	);
 }

--- a/frontend/scripts/survey.js
+++ b/frontend/scripts/survey.js
@@ -325,14 +325,29 @@ export class SurveyManager {
     /**
      * Submit the currentSurvey to the server via websocket
      * @param {WebSocket} socket - the socket the survey is to be sent over
+     * @param {Object} additionalData - additional data to be sent to the server
+     *      along with the survey, must be JSON.stringify-able
      * @returns {boolean}
      */
-    submitSurveyToServer(socket) {
+    submitSurveyToServer(socket, additionalData) {
+        // Create message object
         var msg = {
             type: "submit",
             survey: this.survey.toJSON()
         }
 
+        // Append additional data
+        if (additionalData) {
+            for (let prop in additionalData) {
+                if (
+                    Object.prototype.hasOwnProperty.call(additionalData, prop)
+                ) {
+                    msg[prop] = additionalData[prop];
+                }
+            }
+        }
+
+        // Try sending the message
         if (socket.readyState == WebSocket.OPEN) {
             socket.send(JSON.stringify(msg));
             this.currentField = null;

--- a/frontend/scripts/survey.js
+++ b/frontend/scripts/survey.js
@@ -276,6 +276,18 @@ export class Survey {
             this.projectedFields.push(field);
         }
     }
+
+    /**
+     * The set of meshes used by the survey
+     * @returns {Set}
+     */
+    get usedMeshFilenames() {
+        var list = [];
+        for (let i = 0; i < this.projectedFields.length; i++) {
+            list.push(this.config.models[this.projectedFields[i].model]);
+        }
+        return new Set(list);
+    }
 }
 
 /**

--- a/frontend/scripts/surveyViewport.js
+++ b/frontend/scripts/surveyViewport.js
@@ -862,13 +862,16 @@ export class SurveyViewport {
     
     /**
      * Return mesh parameters for each mesh in meshStorage
+     * @param {Set} [meshes] - the meshes whose parameters should 
+     *      be retrieved
      * @returns {Object}
      */
-    getStoredMeshParameters() {
+    getStoredMeshParameters(meshes = null) {
         var result = {};
 
         for (let prop in this.meshStorage) {
-            if (Object.prototype.hasOwnProperty.call(this.meshStorage, prop)) {
+            if (Object.prototype.hasOwnProperty.call(this.meshStorage, prop)
+            && (!meshes || (meshes && meshes.has(prop)))) {
                 result[prop] = this.getMeshParameters(
                     this.meshStorage[prop], 
                     prop

--- a/frontend/scripts/surveyViewport.js
+++ b/frontend/scripts/surveyViewport.js
@@ -438,6 +438,13 @@ export class SurveyViewport {
     }
 
     /**
+     * Clear all saved meshes from the meshStorage property
+     */
+    clearMeshStorage() {
+        this.meshStorage = {};
+    }
+
+    /**
      * Queues the next frame and handles control inputs depending on the current
      * controlState. Must be called once to begin animating the scene.
      */
@@ -779,7 +786,11 @@ export class SurveyViewport {
                     this.unloadCurrentMesh();
                 }
 
-                if (this.meshStorage.hasOwnProperty(filename)) {
+                if (
+                    Object.prototype.hasOwnProperty.call(
+                        this.meshStorage, filename
+                    )
+                ) {
                     console.log("Mesh in storage");
                     var mesh = this.meshStorage[filename];
                     prepareMesh(this, mesh);
@@ -818,7 +829,7 @@ export class SurveyViewport {
      * reconstruct the mesh post-hoc
      * @param {THREE.Mesh} mesh - the mesh whose parameters will be returned
      * @param {string} [filename] - the filename from which the mesh was loaded
-     * @returns {JSON}
+     * @returns {Object}
      */
     getMeshParameters(mesh, filename = "") {
         const geometry = mesh.geometry;
@@ -847,6 +858,25 @@ export class SurveyViewport {
             "vertices": vertices,
             "faces": faces
         }
+    }
+    
+    /**
+     * Return mesh parameters for each mesh in meshStorage
+     * @returns {Object}
+     */
+    getStoredMeshParameters() {
+        var result = {};
+
+        for (let prop in this.meshStorage) {
+            if (Object.prototype.hasOwnProperty.call(this.meshStorage, prop)) {
+                result[prop] = this.getMeshParameters(
+                    this.meshStorage[prop], 
+                    prop
+                );
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/frontend/scripts/surveyViewport.js
+++ b/frontend/scripts/surveyViewport.js
@@ -791,7 +791,6 @@ export class SurveyViewport {
                         this.meshStorage, filename
                     )
                 ) {
-                    console.log("Mesh in storage");
                     var mesh = this.meshStorage[filename];
                     prepareMesh(this, mesh);
                     resolve(true);

--- a/frontend/scripts/surveyViewport.js
+++ b/frontend/scripts/surveyViewport.js
@@ -740,6 +740,21 @@ export class SurveyViewport {
             });
         });
     }
+    
+    /**
+     * Takes the filename of a model, loads it, then stores the resulting mesh
+     * in the meshStorage
+     * @param {string} filename 
+     * @returns {Promise}
+     */
+    loadMeshIntoStorage(filename) {
+        return new Promise(function(resolve, reject) {
+            this.loadModel(filename).then(function(value) {
+                this.meshStorage[filename] = value;
+                resolve(true);
+            }.bind(this));
+        }.bind(this));
+    }
 
     /**
      * Replaces the current mesh object with a new mesh
@@ -835,7 +850,6 @@ export class SurveyViewport {
 
         var vertices = [];
         const position = geometry.getAttribute("position").array;
-        console.log(position);
 
         for (let i = 0; i < position.length/3; i++) {
             vertices.push([
@@ -845,7 +859,6 @@ export class SurveyViewport {
 
         var faces = [];
         const index = geometry.index.array;
-        console.log(index);
         for (let i = 0; i < index.length/3; i++) {
             faces.push([
                 index[i * 3], index[i * 3 + 1], index[i * 3 + 2]
@@ -1066,6 +1079,8 @@ export class SurveyViewport {
         }
     }
 
+    /* SPECIAL PROPERTIES */
+
     /**
      * Getter for the position of the orbMesh object
      */
@@ -1075,5 +1090,12 @@ export class SurveyViewport {
             y: this.orbMesh.position.y,
             z: this.orbMesh.position.z,
         }
+    }
+
+    /**
+     * Getter for all names in 
+     */
+    get storedMeshNames() {
+        return new Set(Object.keys(this.meshStorage));
     }
 }

--- a/frontend/scripts/surveyViewport.js
+++ b/frontend/scripts/surveyViewport.js
@@ -795,6 +795,34 @@ export class SurveyViewport {
         }.bind(this));
     }
 
+    getCurrentMeshParameters() {
+        const geometry = this.currentMesh.geometry;
+
+        var vertices = [];
+        const position = geometry.getAttribute("position").array;
+        console.log(position);
+
+        for (let i = 0; i < position.length/3; i++) {
+            vertices.push([
+                position[i * 3], position[i * 3 + 1], position[i * 3 + 2]
+            ]);
+        }
+
+        var faces = [];
+        const index = geometry.index.array;
+        console.log(index);
+        for (let i = 0; i < index.length/3; i++) {
+            faces.push([
+                index[i * 3], index[i * 3 + 1], index[i * 3 + 2]
+            ]);
+        }
+
+        return {
+            "vertices": vertices,
+            "faces": faces
+        }
+    }
+
     /**
      * Draws a sphere with the given parameter then uses the given mesh's
      * bounds tree to quickly find what vertex indices exist within the


### PR DESCRIPTION
When loading a mesh for use in a survey, its geometry is changed to "non-indexed" mode (with the three.js method (toNonIndexed). This allows the faces to be separated and for vertex colors to appear clearly. However, this does mean that if a user desired to reconstruct the data reported in the survey, they would not be able to do so with the original model.

This update saves the vertex positions and which vertices constitute which faces to a json when a survey is submitted. This way, users can have copies of the exact mesh used in three.js when the survey was administered. 